### PR TITLE
Adjust responsive fonts for KPIs

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
             font-weight: 700;
             color: #243051;
             letter-spacing: 2px;
+            white-space: nowrap;
         }
         .filters {
             display: flex;
@@ -103,6 +104,7 @@
             font-size: 1.15rem;
             font-weight: 700;
             color: #243051;
+            white-space: nowrap;
         }
         .category-list {
             list-style: none;
@@ -152,6 +154,15 @@
                 font-size: 1.6rem;
                 text-align: center;
             }
+            .kpi .title {
+                font-size: 0.95rem;
+            }
+            .kpi .value {
+                font-size: 1.8rem;
+            }
+            .dashboard-rows .card h3 {
+                font-size: 1rem;
+            }
             .kpis {
                 flex-direction: column;
                 gap: 18px;
@@ -163,6 +174,18 @@
             }
             .dashboard-rows .card {
                 padding: 16px 7px 18px 7px;
+            }
+            .logo {
+                font-size: 1.4rem;
+            }
+            .kpi .title {
+                font-size: 0.85rem;
+            }
+            .kpi .value {
+                font-size: 1.6rem;
+            }
+            .dashboard-rows .card h3 {
+                font-size: 0.95rem;
             }
         }
     </style>


### PR DESCRIPTION
## Summary
- keep header text on one line using `white-space: nowrap`
- shrink KPI font sizes on small screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6854e42288fc832bb0874f1ee4e45844